### PR TITLE
add poseidon hash function. use poseidon in merkle tree

### DIFF
--- a/ts/MerkleTree.ts
+++ b/ts/MerkleTree.ts
@@ -1,6 +1,7 @@
-import { SnarkBigInt, MimcSpongeHasher } from './mimcsponge'
+import { SnarkBigInt } from './common'
+import { PoseidonHasher } from './poseidon'
 
-const mimcspongeHasher = new MimcSpongeHasher()
+const poseidonHasher = new PoseidonHasher()
 
 export type ChildLocation = 0 | 1   // 0 = left, 1 = right
 
@@ -39,7 +40,7 @@ export class MerkleTree {
 		_hashLeftRight: (
 			left: SnarkBigInt,
 			right: SnarkBigInt
-		) => SnarkBigInt = mimcspongeHasher.hash
+		) => SnarkBigInt = poseidonHasher.hash
 	) {
 		this.depth = _depth
 		this.zeroValue = _zero_value

--- a/ts/__tests__/Hasher.test.ts
+++ b/ts/__tests__/Hasher.test.ts
@@ -1,31 +1,41 @@
 import * as crypto from 'crypto'
-
-import {
-	bigInt,
-	SnarkBigInt,
-	SNARK_FIELD_SIZE,
-	MimcSpongeHasher,
-} from '../mimcsponge'
+import { MimcSpongeHasher } from '../mimcsponge'
+import { PoseidonHasher } from '../poseidon'
+import { bigInt, SnarkBigInt, SNARK_FIELD_SIZE } from '../common'
 
 const rbigInt = (nbytes: number): SnarkBigInt => {
 	return bigInt.leBuff2int(crypto.randomBytes(nbytes))
 }
 
 describe('Hash functions', () => {
-	const hasher = new MimcSpongeHasher()
+  describe('MiMC Sponge', () => {
+    const hasher = new MimcSpongeHasher()
 
-	it('should return correct hash', () => {
-		const hash = hasher.hash(
-			rbigInt(Math.floor(Math.random() * 1000)),
-			rbigInt(Math.floor(Math.random() * 1000))
-		)
-		expect(hash.lt(SNARK_FIELD_SIZE)).toBeTruthy()
-	})
+    it('should return correct hash', () => {
+      const hash = hasher.hash(
+        rbigInt(Math.floor(Math.random() * 1000)),
+        rbigInt(Math.floor(Math.random() * 1000))
+      )
+      expect(hash.lt(SNARK_FIELD_SIZE)).toBeTruthy()
+    })
 
-	it('shoudl return correct hash from hashOne function', () => {
-		const hash_one = hasher.hashOne(
-			rbigInt(Math.floor(Math.random() * 1000))
-		)
-		expect(hash_one.lt(SNARK_FIELD_SIZE)).toBeTruthy()
-	})
+    it('shoudl return correct hash from hashOne function', () => {
+      const hash_one = hasher.hashOne(
+        rbigInt(Math.floor(Math.random() * 1000))
+      )
+      expect(hash_one.lt(SNARK_FIELD_SIZE)).toBeTruthy()
+    })
+  })
+
+  describe('Poseidon', () => {
+    const hasher = new PoseidonHasher()
+
+    it('should return correct hash', () => {
+      const hash = hasher.hash(
+        rbigInt(Math.floor(Math.random() * 1000)),
+        rbigInt(Math.floor(Math.random() * 1000))
+      )
+      expect(hash.lt(SNARK_FIELD_SIZE)).toBeTruthy()
+    })
+  })
 })

--- a/ts/__tests__/MerkleTree.test.ts
+++ b/ts/__tests__/MerkleTree.test.ts
@@ -1,10 +1,11 @@
 import { MerkleTree } from '../MerkleTree'
-import { bigInt, SnarkBigInt, MimcSpongeHasher } from '../mimcsponge'
+import { PoseidonHasher } from '../poseidon'
+import { bigInt, SnarkBigInt } from '../common'
 
 const DEPTH = 2
 const ZERO_VALUE = bigInt(0)
 
-const mimcspongeHasher = new MimcSpongeHasher()
+const poseidonHasher = new PoseidonHasher()
 
 /*
  * Calculate a merkle root given a list of leaves
@@ -22,8 +23,8 @@ const calculateRoot = (
 	for (let i = 0; i < numLeafHashers; i++) {
 		hashes.push(
 			tree.hashLeftRight(
-				mimcspongeHasher.hashOne(unhashedLeaves[i * 2]),
-				mimcspongeHasher.hashOne(unhashedLeaves[i * 2 + 1])
+				poseidonHasher.hashOne(unhashedLeaves[i * 2]),
+				poseidonHasher.hashOne(unhashedLeaves[i * 2 + 1])
 			)
 		)
 	}
@@ -46,7 +47,7 @@ describe('MerkleTree', () => {
 
 	it('should initialize correctly', () => {
 		const INITIAL_ROOT = bigInt(
-			'8234632431858659206959486870703726442454087730228411315786216865106603625166'
+      '7423237065226347324353380772367382631490014989348495481811164164159255474657'
 		)
 
 		const tree2 = new MerkleTree(DEPTH, ZERO_VALUE)
@@ -65,7 +66,7 @@ describe('MerkleTree', () => {
 		for (let i = 0; i < 2 ** DEPTH; i++) {
 			const leaf = bigInt(i + 1)
 			leaves.push(leaf)
-			tree.insert(mimcspongeHasher.hashOne(leaf))
+			tree.insert(poseidonHasher.hashOne(leaf))
 		}
 
 		expect(calculateRoot(leaves, tree).toString()).toEqual(
@@ -78,14 +79,14 @@ describe('MerkleTree', () => {
 		const tree2 = new MerkleTree(DEPTH, ZERO_VALUE)
 
 		for (let i = 0; i < 2 ** DEPTH; i++) {
-			tree1.insert(mimcspongeHasher.hashOne(i + 1))
-			tree2.insert(mimcspongeHasher.hashOne(i + 1))
+			tree1.insert(poseidonHasher.hashOne(i + 1))
+			tree2.insert(poseidonHasher.hashOne(i + 1))
 		}
 
 		expect(tree1.root.toString()).toEqual(tree2.root.toString())
 
 		const indexToUpdate = 1
-		const newVal = mimcspongeHasher.hashOne(bigInt(4))
+		const newVal = poseidonHasher.hashOne(bigInt(4))
 		tree1.update(indexToUpdate, newVal)
 
 		expect(tree1.root).not.toEqual(tree2.root)

--- a/ts/common.ts
+++ b/ts/common.ts
@@ -1,0 +1,8 @@
+export const bigInt = require('./bigInt')
+
+// prime number for babyjubjub ec
+export const SNARK_FIELD_SIZE = bigInt(
+	'21888242871839275222246405745257275088548364400416034343698204186575808495617'
+)
+
+export type SnarkBigInt = typeof bigInt

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,4 +1,4 @@
 import { MerkleTree } from './MerkleTree'
-import { bigInt, SnarkBigInt } from './mimcsponge'
+import { SnarkBigInt, bigInt } from './common'
 
 export { MerkleTree, bigInt, SnarkBigInt }

--- a/ts/mimcsponge.ts
+++ b/ts/mimcsponge.ts
@@ -1,15 +1,7 @@
 import * as circomlib from 'circomlib'
-
-const bigInt = require('./bigInt')
-
-type SnarkBigInt = typeof bigInt
+import { SnarkBigInt } from './common'
 
 const mimcsponge = circomlib.mimcsponge
-
-// prime number for babyjubjub ec
-const SNARK_FIELD_SIZE = bigInt(
-	'21888242871839275222246405745257275088548364400416034343698204186575808495617'
-)
 
 interface IHasher {
 	hash: Function
@@ -25,4 +17,4 @@ class MimcSpongeHasher implements IHasher {
 	}
 }
 
-export { bigInt, SnarkBigInt, SNARK_FIELD_SIZE, MimcSpongeHasher }
+export { SnarkBigInt, MimcSpongeHasher }

--- a/ts/poseidon.ts
+++ b/ts/poseidon.ts
@@ -1,0 +1,18 @@
+import * as circomlib from 'circomlib'
+import { SnarkBigInt } from './common'
+
+interface IHasher {
+	hash: (left: SnarkBigInt, right: SnarkBigInt) => SnarkBigInt
+}
+
+class PoseidonHasher implements IHasher {
+	public hash(left: SnarkBigInt, right: SnarkBigInt): SnarkBigInt {
+		return circomlib.poseidon([left, right])
+	}
+
+	public hashOne(preImage: SnarkBigInt): SnarkBigInt {
+		return circomlib.poseidon([preImage, preImage])
+	}
+}
+
+export { PoseidonHasher }


### PR DESCRIPTION
- add poseidon hash function
- use poseidoh hash in MerkleTree instead of mimcsponge
- move commonly used definitions to common.ts