### PR TITLE
Change default hasher from MiMC to Poseidon

### DIFF
--- a/ts/MerkleTree.ts
+++ b/ts/MerkleTree.ts
@@ -1,6 +1,8 @@
 import { SnarkBigInt, MimcSpongeHasher } from './mimcsponge'
+import { PoseidonHasher } from './poseidon'
 
 const mimcspongeHasher = new MimcSpongeHasher()
+const poseidonHasher = new PoseidonHasher()
 
 export type ChildLocation = 0 | 1   // 0 = left, 1 = right
 
@@ -39,7 +41,7 @@ export class MerkleTree {
 		_hashLeftRight: (
 			left: SnarkBigInt,
 			right: SnarkBigInt
-		) => SnarkBigInt = mimcspongeHasher.hash
+		) => SnarkBigInt = poseidonHasher.hash
 	) {
 		this.depth = _depth
 		this.zeroValue = _zero_value

--- a/ts/poseidon.ts
+++ b/ts/poseidon.ts
@@ -1,0 +1,21 @@
+import * as circomlib from 'circomlib'
+
+const bigInt = require('./bigInt')
+
+type SnarkBigInt = typeof bigInt
+
+interface IHasher {
+	hash: (left: SnarkBigInt, right: SnarkBigInt) => SnarkBigInt
+}
+
+class PoseidonHasher implements IHasher {
+	public hash(left: SnarkBigInt, right: SnarkBigInt): SnarkBigInt {
+		return circomlib.poseidon([left, right])
+	}
+
+	public hashOne(preImage: SnarkBigInt): SnarkBigInt {
+		return circomlib.poseidon([preImage, preImage])
+	}
+}
+
+export { PoseidonHasher }


### PR DESCRIPTION
Add Poseidon hasher that is based on circomlib/poseidon, and make Poseidon hasher the default hasher of MerkleTree._hashLeftRight function.