### PR TITLE
enrich comments. rename variable names

### DIFF
--- a/ts/MerkleTree.ts
+++ b/ts/MerkleTree.ts
@@ -1,11 +1,35 @@
-import { SnarkBigInt, MimcSpongeHasher } from './mimcsponge'
+import { SnarkBigInt } from './mimcsponge'
 import { PoseidonHasher } from './poseidon'
 
-const mimcspongeHasher = new MimcSpongeHasher()
 const poseidonHasher = new PoseidonHasher()
 
 export type ChildLocation = 0 | 1   // 0 = left, 1 = right
 
+// Merkle tree implementation that sparsely represents a tree at each level.
+// The tree data strucutre is originally empty. As a leaf is added at the bottom level, 
+// above that level up to root, only parent nodes are added to the data structure.
+//
+// At each level, when a LHS node is newly added, the value is cached in order to  
+// calculate the parent hash next time w/ the newly coming RHS node
+//
+// Below example shows how the data structure represents the tree. 
+// '.' means empty and a number means filled.
+//
+// 1. Initially the tree is empty 
+//        .
+//      .   .
+//     . . . .
+//
+// 2. A leaf is added. The data structure contains 3 nodes. 2 and 3 are cached.
+//        1
+//      2   .
+//     3 . . .
+//
+// 3. Another leaf is added. The data structure contain 4 nodes. To recalculate 2, cached 3 was used.
+//        1
+//      2   .
+//     3 4 . .
+//
 export class MerkleTree {
 	// tree depth
 	public depth: number
@@ -28,12 +52,15 @@ export class MerkleTree {
 	// total number of leaves
 	public leafNumber: number
 
-	//cached values required to compute Merkle proofs
-	public zeros: {[level: number]: SnarkBigInt}  // zero values of each level
-	public filledSubtrees: {[level: number]: SnarkBigInt}  // values on most recent path from inserted value to root
+	// zero values that are pre-calculted at each level 
+	public zeros: {[level: number]: SnarkBigInt}
 
-	// partial tree w/ inserted values, hashes created from it and values used to created the hashes
-	public filledPaths: {[level: number]: {[index: number]: SnarkBigInt}}
+	// cache of most recently added LHS child at each level
+	public lastCalculatedNodeValueAtLevel: {[level: number]: SnarkBigInt} 
+
+	// filled nodes so far at each level. each level is represented 
+	// as an array of hashes filled from left to  eight
+	public filledNodesAtLevel: {[level: number]: {[index: number]: SnarkBigInt}}
 
 	constructor(
 		_depth: number,
@@ -48,19 +75,18 @@ export class MerkleTree {
 		this.hashLeftRight = _hashLeftRight
 		this.nextIndex = 0
 		this.zeros = { 0: this.zeroValue }
-		this.filledSubtrees = { 0: this.zeroValue }
-		this.filledPaths = { 0: {} }
+		this.lastCalculatedNodeValueAtLevel = { 0: this.zeroValue }
+		this.filledNodesAtLevel = { 0: {} }
 		this.leafNumber = Math.pow(2, this.depth)
 
-		// create initial merkletree with zero value
-		// with given N levels and zeroValue
+		// create empty merkletree using given zero value at leaf level
 		for (let i = 1; i < _depth; i++) {
 			this.zeros[i] = this.hashLeftRight(
 				this.zeros[i - 1],
 				this.zeros[i - 1]
 			)
-			this.filledSubtrees[i] = this.zeros[i]
-			this.filledPaths[i] = {}
+			this.lastCalculatedNodeValueAtLevel[i] = this.zeros[i]
+			this.filledNodesAtLevel[i] = {}
 		}
 
 		// compute the merkle root
@@ -71,7 +97,7 @@ export class MerkleTree {
 	}
 
 	/*
-	 * insert a leaf into the merkle tree
+	 * Insert a new leaf into the tree
 	 * @param _value the value to insert
 	 */
 	public insert(_value: SnarkBigInt) {
@@ -91,15 +117,15 @@ export class MerkleTree {
 				left = currentLevelHash
 				right = this.zeros[i]
 
-				this.filledSubtrees[i] = currentLevelHash
-				this.filledPaths[i][curIdx] = left
-				this.filledPaths[i][curIdx + 1] = right
+				this.lastCalculatedNodeValueAtLevel[i] = currentLevelHash
+				this.filledNodesAtLevel[i][curIdx] = left
+				this.filledNodesAtLevel[i][curIdx + 1] = right
 			} else {
-				left = this.filledSubtrees[i]
+				left = this.lastCalculatedNodeValueAtLevel[i]
 				right = currentLevelHash
 
-				this.filledPaths[i][curIdx - 1] = left
-				this.filledPaths[i][curIdx] = right
+				this.filledNodesAtLevel[i][curIdx - 1] = left
+				this.filledNodesAtLevel[i][curIdx] = right
 			}
 
 			currentLevelHash = this.hashLeftRight(left, right)
@@ -111,7 +137,7 @@ export class MerkleTree {
 	}
 
 	/*
-	 * update the leaf at the specified index with the given value
+	 * Changes the leaf at the specified index and updates the tree
 	 */
 	public update(_leafIndex: number, _value: SnarkBigInt) {
 		if (_leafIndex >= this.nextIndex) {
@@ -129,14 +155,14 @@ export class MerkleTree {
 
 		this.leaves = newTree.leaves
 		this.zeros = newTree.zeros
-		this.filledPaths = newTree.filledPaths
-		this.filledSubtrees = newTree.filledSubtrees
+		this.filledNodesAtLevel = newTree.filledNodesAtLevel
+		this.lastCalculatedNodeValueAtLevel = newTree.lastCalculatedNodeValueAtLevel
 		this.root = newTree.root
 		this.nextIndex = newTree.nextIndex
 	}
 
 	/*
-	 * returns the leaf value at the given index
+	 * Returns the leaf value at the given index
 	 */
 	public getLeaf(_leafIndex: number | SnarkBigInt): SnarkBigInt {
 		const leafIndex = parseInt(_leafIndex.toString(), 10)
@@ -145,9 +171,14 @@ export class MerkleTree {
 	}
 
 	/*
-	 * returns the path needed to construct a tree root
-	 * used for quick verification on updates
-	 * runs in O(log(N)), where N is the number of leaves
+	 * Returns the path needed to construct a tree root where the path is 
+	 * represented by 2 lists.
+	 * One is a list of counterparts at each level to calculate the hash 
+	 * of the parent, and the other is a list of child indices where child 
+	 * index is 0 or 1, representing LHS and RHS child respentively.
+	 * 
+	 * Used for quick verification on updates
+	 * Runs in O(log(N)), where N is the number of leaves
 	 */
 	public getPathUpdate(
 		_leafIndex: number | SnarkBigInt
@@ -163,10 +194,10 @@ export class MerkleTree {
 
 		for (let i = 0; i < this.depth; i++) {
 			if (curIdx % 2 === 0) {
-				path.push(this.filledPaths[i][curIdx + 1])
+				path.push(this.filledNodesAtLevel[i][curIdx + 1])
 				pathIndex.push(0)
 			} else {
-				path.push(this.filledPaths[i][curIdx - 1])
+				path.push(this.filledNodesAtLevel[i][curIdx - 1])
 				pathIndex.push(1)
 			}
 			curIdx = Math.floor(curIdx / 2)

--- a/ts/__tests__/MerkleTree.test.ts
+++ b/ts/__tests__/MerkleTree.test.ts
@@ -1,10 +1,11 @@
 import { MerkleTree } from '../MerkleTree'
-import { bigInt, SnarkBigInt, MimcSpongeHasher } from '../mimcsponge'
+import { bigInt, SnarkBigInt } from '../mimcsponge'
+import { PoseidonHasher } from '../poseidon'
 
 const DEPTH = 2
 const ZERO_VALUE = bigInt(0)
 
-const mimcspongeHasher = new MimcSpongeHasher()
+const hasher = new PoseidonHasher()
 
 /*
  * Calculate a merkle root given a list of leaves
@@ -22,8 +23,8 @@ const calculateRoot = (
 	for (let i = 0; i < numLeafHashers; i++) {
 		hashes.push(
 			tree.hashLeftRight(
-				mimcspongeHasher.hashOne(unhashedLeaves[i * 2]),
-				mimcspongeHasher.hashOne(unhashedLeaves[i * 2 + 1])
+				hasher.hashOne(unhashedLeaves[i * 2]),
+				hasher.hashOne(unhashedLeaves[i * 2 + 1])
 			)
 		)
 	}
@@ -65,7 +66,7 @@ describe('MerkleTree', () => {
 		for (let i = 0; i < 2 ** DEPTH; i++) {
 			const leaf = bigInt(i + 1)
 			leaves.push(leaf)
-			tree.insert(mimcspongeHasher.hashOne(leaf))
+			tree.insert(hasher.hashOne(leaf))
 		}
 
 		expect(calculateRoot(leaves, tree).toString()).toEqual(
@@ -78,14 +79,14 @@ describe('MerkleTree', () => {
 		const tree2 = new MerkleTree(DEPTH, ZERO_VALUE)
 
 		for (let i = 0; i < 2 ** DEPTH; i++) {
-			tree1.insert(mimcspongeHasher.hashOne(i + 1))
-			tree2.insert(mimcspongeHasher.hashOne(i + 1))
+			tree1.insert(hasher.hashOne(i + 1))
+			tree2.insert(hasher.hashOne(i + 1))
 		}
 
 		expect(tree1.root.toString()).toEqual(tree2.root.toString())
 
 		const indexToUpdate = 1
-		const newVal = mimcspongeHasher.hashOne(bigInt(4))
+		const newVal = hasher.hashOne(bigInt(4))
 		tree1.update(indexToUpdate, newVal)
 
 		expect(tree1.root).not.toEqual(tree2.root)


### PR DESCRIPTION
- MerkleTree.ts
  - Enrich the overall comments to make it easier for the new reader to understand the implementation
  - Rename 2 variables to better represent what they do
- MerkleTree.test.ts
  - Fix to use Poseidon hasher