### PR TITLE
export ChildLocation

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,4 +1,9 @@
-import { MerkleTree } from './MerkleTree'
+import { MerkleTree, ChildLocation } from './MerkleTree'
 import { bigInt, SnarkBigInt } from './mimcsponge'
 
-export { MerkleTree, bigInt, SnarkBigInt }
+export {
+  MerkleTree,
+  ChildLocation,
+  bigInt,
+  SnarkBigInt,
+}


### PR DESCRIPTION
Export ChildLocation interface used in MerkleTree which is needed to use MerkleTree from outside.